### PR TITLE
Fix template file parsing regex to match file with names starting with 'template'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ enum AppCommand {
             short = "f",
             long = "templates-filter",
             parse(try_from_str = "App::parse_regex"),
-            default_value = "^[^.]*(\w+\.)*template([-.].+)?\.(config|ya?ml|properties)",
+            default_value = "^[^.]*(\\w+\\.)*template([-.].+)?\\.(config|ya?ml|properties)",
             value_name = "REGEX"
         )]
         templates_regex: Regex,

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,7 +346,7 @@ mod tests {
         );
 
         cmd.assert()
-            .stdout(predicate::str::contains("Loaded 3 template file(s)").from_utf8());
+            .stdout(predicate::str::contains("Loaded 6 template file(s)").from_utf8());
 
         cmd.assert().stdout(
             predicate::str::contains(r#"Finding Files: "tests/fixtures/configs""#).from_utf8(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ enum AppCommand {
             short = "f",
             long = "templates-filter",
             parse(try_from_str = "App::parse_regex"),
-            default_value = "^[^.].*template([-.].+)?\\.(config|ya?ml|properties)",
+            default_value = "^[^.]*(\w+\.)*template([-.].+)?\.(config|ya?ml|properties)",
             value_name = "REGEX"
         )]
         templates_regex: Regex,
@@ -341,7 +341,7 @@ mod tests {
         );
 
         cmd.assert().stdout(
-           predicate::str::contains(r"regex: /^[^.].*template([-.].+)?\.(config|ya?ml|properties)/")
+           predicate::str::contains(r"regex: /^[^.]*(\w+\.)*template([-.].+)?\.(config|ya?ml|properties)/")
                .from_utf8(),
         );
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -105,11 +105,11 @@ mod tests {
         let template_dir =
             TemplateDir::new(PathBuf::from("tests/fixtures/projects/templates")).unwrap();
         let templates = template_dir.find(
-            RegexBuilder::new("(.*\\.)?template(\\.Release|\\-liquibase|\\-quartz)?\\.([Cc]onfig|yaml|properties)$")
+            RegexBuilder::new("^[^.]*(\\w+\\.)*template([-.].+)?\\.(config|ya?ml|properties)$")
                 .case_insensitive(true)
                 .build()
                 .unwrap(),
         );
-        assert_eq!(templates.len(), 3)
+        assert_eq!(templates.len(), 6)
     }
 }

--- a/tests/fixtures/projects/templates/.gitignore
+++ b/tests/fixtures/projects/templates/.gitignore
@@ -1,3 +1,4 @@
 *.*
 !*.template.*
 !.gitignore
+!template.*

--- a/tests/fixtures/projects/templates/project-4/template.config
+++ b/tests/fixtures/projects/templates/project-4/template.config
@@ -1,0 +1,1 @@
+#testing that templates starting with `template` and ending with `.config` get picked up by the regex

--- a/tests/fixtures/projects/templates/project-4/template.properties
+++ b/tests/fixtures/projects/templates/project-4/template.properties
@@ -1,0 +1,1 @@
+#testing that templates starting with `template` and ending with `.properties` get picked up by the regex

--- a/tests/fixtures/projects/templates/project-4/template.yaml
+++ b/tests/fixtures/projects/templates/project-4/template.yaml
@@ -1,0 +1,1 @@
+#testing that templates starting with `template` and ending with `.yaml` get picked up by the regex


### PR DESCRIPTION
Regex tested: 
```
abc.template.yaml -> match
.template.yaml -> no match
template.yaml -> match
abc.def.template.yaml -> match
template-liquibase.yaml -> match
```
Regex reference:
https://regex101.com/r/CQ2l2F/1