### PR TITLE
Add shared processing for head requests and move blocking activities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "actix-service"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e4fc95dfa7e24171b2d0bb46b85f8ab0e8499e4e3caec691fc4ea65c287564"
+checksum = "0052435d581b5be835d11f4eb3bce417c8af18d87ddf8ace99f8e67e595882bb"
 dependencies = [
  "futures-util",
  "pin-project",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.36"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
+checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -527,9 +527,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.2"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
@@ -681,9 +681,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "encoding_rs"
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4bfcfacb61d231109d1d55202c1f33263319668b168843e02ad4652725ec9c"
+checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -961,23 +961,23 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dbc8a0746b08f363d2e00da48e6c9ceb75c198ac692d2715fcbb5bee74c87d"
+checksum = "5deefd4816fb852b1ff3cb48f6c41da67be2d0e1d20b26a7a3b076da11f064b1"
 dependencies = [
  "log",
  "pest",
  "pest_derive",
- "quick-error",
+ "quick-error 2.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
  "autocfg",
 ]
@@ -1034,6 +1034,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "threadpool",
+ "tokio",
  "url",
  "walkdir",
  "zip",
@@ -1080,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1225,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.25"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+checksum = "af67924b8dd885cccea261866c8ce5b74d239d272e154053ff927dae839f5ae9"
 dependencies = [
  "cc",
  "libc",
@@ -1415,9 +1416,9 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "opaque-debug"
@@ -1660,6 +1661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-error"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,7 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
 dependencies = [
  "hostname",
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -1829,18 +1836,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1915,9 +1922,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
@@ -2081,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
@@ -2135,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
  "log",
@@ -2146,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d593f98af59ebc017c0648f0117525db358745a8894a8d684e185ba3f45954f9"
+checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
 dependencies = [
  "lazy_static 1.4.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.1"
+version = "2.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
 dependencies = [
  "ansi_term",
  "atty",
@@ -579,6 +579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -992,13 +1002,14 @@ dependencies = [
 
 [[package]]
 name = "hogan"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "actix-rt",
  "actix-service",
  "actix-web",
  "assert_cmd",
  "bincode",
+ "crossbeam-channel",
  "dir-diff",
  "dogstatsd",
  "failure",
@@ -1022,6 +1033,7 @@ dependencies = [
  "stderrlog",
  "structopt",
  "tempfile",
+ "threadpool",
  "url",
  "walkdir",
  "zip",
@@ -1887,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap",
  "libc",
@@ -1940,9 +1952,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
+checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
 dependencies = [
  "clap",
  "lazy_static 1.4.0",
@@ -1951,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
+checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ doc = false
 
 [package]
 name = 'hogan'
-version = '0.8.2'
+version = '0.8.4'
 authors = [
     'Jonathan Morley <jmorley@cvent.com>',
     'Josh Comer <jcomer@cvent.com>',
@@ -36,6 +36,8 @@ futures = '0.3'
 parking_lot = '0.11'
 bincode = '1.3'
 lazy_static = '1'
+crossbeam-channel = '0.4'
+threadpool = '1.8'
 
 [dependencies.rusqlite]
 version = '0.23'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ lazy_static = '1'
 crossbeam-channel = '0.4'
 threadpool = '1.8'
 
+[dependencies.tokio]
+version = '0.2'
+features = ['blocking']
+
 [dependencies.rusqlite]
 version = '0.23'
 features = ['bundled']

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -111,7 +111,7 @@ pub enum AppCommand {
     },
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Clone)]
 pub struct AppCommon {
     /// Config source. Accepts file and git URLs. Paths within a git repository may be appended
     /// to a git URL, and branches may be specified as a URL fragment (recursive if applicable)

--- a/src/app/head.rs
+++ b/src/app/head.rs
@@ -1,0 +1,136 @@
+use crossbeam_channel::{unbounded, Receiver, Sender};
+use failure::Error;
+use hogan::config::ConfigDir;
+use std::collections::hash_map::HashMap;
+use std::sync::Arc;
+use std::thread;
+use threadpool::ThreadPool;
+
+#[derive(Debug, Clone)]
+pub enum HeadRequest {
+    Query {
+        result_channel: Sender<Option<String>>,
+        branch: String,
+    },
+    Result {
+        sha: Option<String>,
+        branch: String,
+    },
+}
+
+impl HeadRequest {
+    fn new_query(branch: &str) -> (Receiver<Option<String>>, Self) {
+        let (s, r) = unbounded();
+        let hr = HeadRequest::Query {
+            result_channel: s,
+            branch: branch.to_owned(),
+        };
+        (r, hr)
+    }
+
+    fn new_result(branch: &str, sha: &str) -> Self {
+        HeadRequest::Result {
+            sha: Some(sha.to_owned()),
+            branch: branch.to_owned(),
+        }
+    }
+
+    fn new_empty_result(branch: &str) -> Self {
+        HeadRequest::Result {
+            sha: None,
+            branch: branch.to_owned(),
+        }
+    }
+}
+
+fn head_query(sender: Sender<HeadRequest>, config: Arc<ConfigDir>, branch: String) {
+    let result = match config.find_branch_head(&"origin", &branch) {
+        Some(sha) => HeadRequest::new_result(&branch, &sha),
+        None => HeadRequest::new_empty_result(&branch),
+    };
+    match sender.send(result) {
+        Ok(()) => {}
+        Err(e) => warn!("Unable to send the result for {} {:?}", branch, e),
+    }
+}
+
+fn worker(sender: Sender<HeadRequest>, receiver: Receiver<HeadRequest>, config: Arc<ConfigDir>) {
+    let tp = ThreadPool::new(4);
+    let mut head_requests: HashMap<String, Vec<Sender<Option<String>>>> = HashMap::new();
+    info!("Started head request worker");
+    loop {
+        let msg = match receiver.recv() {
+            Ok(msg) => msg,
+            Err(e) => {
+                info!("Stopping head worker. Received: {:?}", e);
+                break;
+            }
+        };
+
+        match msg {
+            HeadRequest::Result { sha, branch } => {
+                if head_requests.contains_key(&branch) {
+                    let requests = head_requests.get(&branch).unwrap();
+                    for r in requests {
+                        if let Err(e) = r.try_send(sha.clone()) {
+                            warn!(
+                                "Unable to return head response {:?} {} {:?}",
+                                e, branch, sha
+                            );
+                        }
+                    }
+                    debug!(
+                        "Returned {} head requests for {} {:?}",
+                        requests.len(),
+                        branch,
+                        sha
+                    );
+                    head_requests.remove(&branch);
+                } else {
+                    warn!("Received lost head result for {} -> {:?}", branch, sha);
+                }
+            }
+            HeadRequest::Query {
+                result_channel,
+                branch,
+            } => {
+                if head_requests.contains_key(&branch) {
+                    let requests = head_requests.get_mut(&branch).unwrap();
+                    debug!("Adding request for {} head", branch);
+                    requests.push(result_channel);
+                } else {
+                    debug!("New branch head request {}", branch);
+                    let request = vec![result_channel];
+                    head_requests.insert(branch.clone(), request);
+                    let new_sender = sender.clone();
+                    let new_config = config.clone();
+                    tp.execute(move || head_query(new_sender, new_config, branch));
+                }
+            }
+        }
+    }
+}
+
+pub fn init_head(config: Arc<ConfigDir>) -> Sender<HeadRequest> {
+    let (s, r) = unbounded();
+    let worker_sender = s.clone();
+    thread::spawn(move || worker(worker_sender, r, config));
+    s
+}
+
+pub fn request_branch_head(
+    sender: &Sender<HeadRequest>,
+    branch: &str,
+) -> Result<Option<String>, Error> {
+    let (return_chan, request) = HeadRequest::new_query(branch);
+    match sender.send(request) {
+        Ok(()) => match return_chan.recv_timeout(std::time::Duration::from_secs(60)) {
+            Ok(result) => Ok(result),
+            Err(e) => Err(e.into()),
+        },
+        Err(e) => {
+            warn!("Unable to send head request {} {:?}", branch, e);
+            Err(e.into())
+        }
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,4 +2,5 @@ pub mod cli;
 pub mod config;
 mod datadogstatsd;
 mod db;
+mod head;
 pub mod server;

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -16,6 +16,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
 use std::time::SystemTime;
+use tokio::task;
 
 type EnvCache = Mutex<LruCache<String, Arc<hogan::config::Environment>>>;
 type EnvListingCache = Mutex<LruCache<String, Arc<Vec<EnvDescription>>>>;
@@ -169,7 +170,7 @@ async fn start_server(
     Ok(())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct TransformEnvParams {
     sha: String,
     env: String,
@@ -180,29 +181,43 @@ lazy_static! {
 }
 
 #[post("transform/{sha}/{env}")]
-fn transform_route_sha_env(
+async fn transform_route_sha_env(
     data: String,
     params: web::Path<TransformEnvParams>,
     state: web::Data<ServerState>,
 ) -> HttpResponse {
-    //We keep running into folks that are passing in branch name here and it throws off the caching layer and gives inconsistent results
-    //This won't catch branch names with all hex values, but would catch the common case like 'master'
-    let sha = if !HEX_REGEX.is_match(&params.sha) {
-        if let Some(head_sha) = find_branch_head(&params.sha, &state) {
-            head_sha
+    let sha = params.sha.to_owned();
+    let env = params.env.to_owned();
+    let result = match task::spawn_blocking(move || {
+        //We keep running into folks that are passing in branch name here and it throws off the caching layer and gives inconsistent results
+        //This won't catch branch names with all hex values, but would catch the common case like 'master'
+        let sha = if !HEX_REGEX.is_match(&sha) {
+            if let Some(head_sha) = find_branch_head(&sha, &state) {
+                head_sha
+            } else {
+                return None;
+            }
         } else {
-            return HttpResponse::NotFound().finish();
+            sha
+        };
+
+        match transform_from_sha(data, &sha, &env, &state) {
+            Ok(result) => Some(result),
+            Err(e) => {
+                warn!("Error templating request {} {} {:?}", sha, env, e);
+                None
+            }
         }
-    } else {
-        params.sha.to_owned()
+    })
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return HttpResponse::NotFound().finish(),
     };
 
-    match transform_from_sha(data, &sha, &params.env, &state) {
-        Ok(result) => HttpResponse::Ok().body(result),
-        Err(e) => {
-            warn!("Error templating request {} {} {}", e, sha, params.env);
-            HttpResponse::BadRequest().finish()
-        }
+    match result {
+        Some(body) => HttpResponse::Ok().body(body),
+        None => HttpResponse::BadRequest().finish(),
     }
 }
 
@@ -230,8 +245,17 @@ struct GetEnvsParams {
 }
 
 #[get("envs/{sha}")]
-fn get_envs(params: web::Path<GetEnvsParams>, state: web::Data<ServerState>) -> HttpResponse {
-    match get_env_listing(&state, None, &params.sha) {
+async fn get_envs(params: web::Path<GetEnvsParams>, state: web::Data<ServerState>) -> HttpResponse {
+    let result =
+        match task::spawn_blocking(move || get_env_listing(&state, None, &params.sha)).await {
+            Ok(envs) => envs,
+            Err(e) => {
+                warn!("Error joining on getting environments {:?}", e);
+                return HttpResponse::InternalServerError().finish();
+            }
+        };
+
+    match result {
         Some(envs) => HttpResponse::Ok().json(envs),
         None => HttpResponse::NotFound().finish(),
     }
@@ -244,36 +268,60 @@ struct ConfigByEnvState {
 }
 
 #[get("configs/{sha}/{env}")]
-fn get_config_by_env(
+async fn get_config_by_env(
     params: web::Path<ConfigByEnvState>,
     state: web::Data<ServerState>,
 ) -> HttpResponse {
-    let sha = format_sha(&params.sha);
-    match get_env(&state, None, sha, &params.env) {
+    let sha = format_sha(&params.sha).to_owned();
+
+    let result = match task::spawn_blocking(move || get_env(&state, None, &sha, &params.env)).await
+    {
+        Ok(env) => env,
+        Err(e) => {
+            warn!("Error joining on getting environments {:?}", e);
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+
+    match result {
         Some(env) => HttpResponse::Ok().json(env),
         None => HttpResponse::NotFound().finish(),
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct ConfigByEnvBranchState {
     branch_name: String,
     env: String,
 }
 
 #[get("branch/{branch_name:.*}/configs/{env}")]
-fn get_config_by_env_branch(
+async fn get_config_by_env_branch(
     params: web::Path<ConfigByEnvBranchState>,
     state: web::Data<ServerState>,
 ) -> HttpResponse {
-    if let Some(head_sha) = find_branch_head(&params.branch_name, &state) {
-        let sha = format_sha(&head_sha);
-        match get_env(&state, None, sha, &params.env) {
+    let branch = params.branch_name.to_owned();
+    let env = params.env.to_owned();
+    let result = match task::spawn_blocking(move || {
+        if let Some(head_sha) = find_branch_head(&branch, &state) {
+            let sha = format_sha(&head_sha);
+            Some(get_env(&state, None, sha, &env))
+        } else {
+            None
+        }
+    })
+    .await
+    {
+        Ok(r) => r,
+        Err(_e) => return HttpResponse::InternalServerError().finish(),
+    };
+
+    match result {
+        Some(result) => match result {
             Some(env) => HttpResponse::Ok().json(env),
             None => HttpResponse::NotFound().finish(),
-        }
-    } else {
-        HttpResponse::NotFound().finish()
+        },
+        None => HttpResponse::NotFound().finish(),
     }
 }
 
@@ -300,20 +348,27 @@ fn find_branch_head(branch_name: &str, state: &ServerState) -> Option<String> {
 }
 
 #[get("heads/{branch_name:.*}")]
-fn get_branch_sha(
+async fn get_branch_sha(
     params: web::Path<BranchShaParams>,
     state: web::Data<ServerState>,
 ) -> HttpResponse {
-    let branch_name = &params.branch_name;
+    let branch_name = params.branch_name.to_owned();
     debug!("Looking up branch name {}", branch_name);
+    let result =
+        match task::spawn_blocking(move || find_branch_head(&params.branch_name, &state)).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Error joining from branch sha {} {:?}", branch_name, e);
+                return HttpResponse::InternalServerError().finish();
+            }
+        };
 
-    if let Some(head_sha) = find_branch_head(branch_name, &state) {
-        HttpResponse::Ok().json(ShaResponse {
+    match result {
+        Some(head_sha) => HttpResponse::Ok().json(ShaResponse {
             head_sha,
-            branch_name: branch_name.to_string(),
-        })
-    } else {
-        HttpResponse::NotFound().finish()
+            branch_name,
+        }),
+        None => HttpResponse::NotFound().finish(),
     }
 }
 
@@ -324,27 +379,46 @@ struct BranchHeadTransformParams {
 }
 
 #[post("branch/{branch_name:.*}/transform/{environment}")]
-fn transform_branch_head(
+async fn transform_branch_head(
     data: String,
     params: web::Path<BranchHeadTransformParams>,
     state: web::Data<ServerState>,
 ) -> HttpResponse {
-    if let Some(head_sha) = find_branch_head(&params.branch_name, &state) {
-        match transform_from_sha(data, &head_sha, &params.environment, &state) {
-            Ok(result) => HttpResponse::Ok().body(result),
-            Err(e) => {
-                warn!(
-                    "Error templating request {} {} {}",
-                    e, head_sha, params.environment
-                );
-                HttpResponse::BadRequest().body(format!(
-                    "Unable to template request on branch {} for environment {} - {:?}",
-                    params.branch_name, params.environment, e
-                ))
+    //Pull out values for later use
+    let branch_name = params.branch_name.to_owned();
+    let environment = params.environment.to_owned();
+    //Double wrapped Option representing BRANCH(ENVIRONMENT(TEMPLATE))
+    let result = match task::spawn_blocking(move || {
+        if let Some(head_sha) = find_branch_head(&params.branch_name, &state) {
+            match transform_from_sha(data, &head_sha, &params.environment, &state) {
+                Ok(result) => Some(Some(result)),
+                Err(_) => Some(None),
             }
+        } else {
+            None
         }
-    } else {
-        HttpResponse::NotFound().body(format!("Unknown branch {}", params.branch_name))
+    })
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                "Error joining from a template request {} {} {:?}",
+                environment, branch_name, e
+            );
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+
+    match result {
+        Some(result) => match result {
+            Some(body) => HttpResponse::Ok().body(body),
+            None => HttpResponse::BadRequest().body(format!(
+                "Unable to template request on branch {} for environment {}",
+                branch_name, environment
+            )),
+        },
+        None => HttpResponse::NotFound().body(format!("Unable to template branch {}", branch_name)),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ use tempfile::{self, TempDir};
 use url::{ParseError, Url};
 use walkdir::WalkDir;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ConfigUrl {
     File {
         path: PathBuf,
@@ -85,6 +85,7 @@ impl FromStr for ConfigUrl {
     }
 }
 
+#[derive(Debug)]
 pub enum ConfigDir {
     File {
         directory: PathBuf,


### PR DESCRIPTION
Added some functionality to have concurrent head requests for the same branch share the same result. This also adds a 60-second timeout to the head requests as well. Will result in a 404 on a timeout which is less than desirable though.