### PR TITLE
Better Error Handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "awc"
@@ -687,9 +693,9 @@ checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
+checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
  "cfg-if",
 ]
@@ -775,9 +781,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs_extra"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -927,9 +933,9 @@ checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "git2"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a18853c521bcf553a4e3c05ad21f3ad89c1a78a0485adc97829a4c88066a36"
+checksum = "86d97249f21e9542caeee9f8e1d150905cd875bf723f5ff771bdb4852eb83a24"
 dependencies = [
  "bitflags",
  "libc",
@@ -1004,15 +1010,16 @@ dependencies = [
 name = "hogan"
 version = "0.8.5"
 dependencies = [
+ "actix-http",
  "actix-rt",
  "actix-service",
  "actix-web",
+ "anyhow",
  "assert_cmd",
  "bincode",
  "crossbeam-channel",
  "dir-diff",
  "dogstatsd",
- "failure",
  "fs_extra",
  "futures",
  "git2",
@@ -1033,6 +1040,7 @@ dependencies = [
  "stderrlog",
  "structopt",
  "tempfile",
+ "thiserror",
  "threadpool",
  "tokio",
  "url",
@@ -1187,9 +1195,9 @@ checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.11+1.0.1"
+version = "0.12.12+1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4755167bef8a2959fe4eedeece2ba0f8eb9923b209d46139031f1281d569a2"
+checksum = "0100ae90655025134424939f1f60e27e879460d451dff6afedde4f8226cbebfc"
 dependencies = [
  "cc",
  "libc",
@@ -1307,9 +1315,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
 dependencies = [
  "adler",
 ]
@@ -1959,9 +1967,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
+checksum = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
 dependencies = [
  "clap",
  "lazy_static 1.4.0",
@@ -1970,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
+checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1983,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2046,6 +2054,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2153,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
+checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
 dependencies = [
  "lazy_static 1.4.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "hogan"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "actix-rt",
  "actix-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,6 @@ dependencies = [
 name = "hogan"
 version = "0.8.5"
 dependencies = [
- "actix-http",
  "actix-rt",
  "actix-service",
  "actix-web",
@@ -1209,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
+checksum = "e3a245984b1b06c291f46e27ebda9f369a94a1ab8461d0e845e23f9ced01f5db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1789,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d0fd62e1df63d254714e6cb40d0a0e82e7a1623e7a27f679d851af092ae58b"
+checksum = "4c78c3275d9d6eb684d2db4b2388546b32fdae0586c20a82f3905d21ea78b9ef"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -1800,7 +1799,6 @@ dependencies = [
  "lru-cache",
  "memchr",
  "smallvec",
- "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ authors = [
 edition = '2018'
 
 [dependencies]
-failure = '0.1'
+anyhow = '1.0'
+thiserror = '1.0'
 lru_time_cache = '0.10'
 handlebars = '3.4'
 itertools = '0.9'
@@ -31,6 +32,7 @@ zip = '0.5'
 dogstatsd = '0.6'
 actix-web = '2'
 actix-rt = '1'
+actix-http = '1'
 actix-service = '1'
 futures = '0.3'
 parking_lot = '0.11'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ doc = false
 
 [package]
 name = 'hogan'
-version = '0.8.5'
+version = '0.9.0'
 authors = [
     'Jonathan Morley <jmorley@cvent.com>',
     'Josh Comer <jcomer@cvent.com>',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ zip = '0.5'
 dogstatsd = '0.6'
 actix-web = '2'
 actix-rt = '1'
-actix-http = '1'
 actix-service = '1'
 futures = '0.3'
 parking_lot = '0.11'
@@ -46,7 +45,7 @@ version = '0.2'
 features = ['blocking']
 
 [dependencies.rusqlite]
-version = '0.23'
+version = '0.24'
 features = ['bundled']
 
 [dependencies.git2]

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::{Context, Result};
 use hogan::config::ConfigUrl;
 use regex::{Regex, RegexBuilder};
 use std::path::PathBuf;
@@ -134,11 +134,11 @@ pub struct AppCommon {
 }
 
 impl App {
-    pub fn config_regex(environment: &Regex) -> Result<Regex, Error> {
+    pub fn config_regex(environment: &Regex) -> Result<Regex> {
         App::parse_regex(&format!("config\\.{}\\.json$", environment))
     }
 
-    pub fn parse_regex(src: &str) -> Result<Regex, Error> {
+    pub fn parse_regex(src: &str) -> Result<Regex> {
         RegexBuilder::new(src)
             .case_insensitive(true)
             .build()

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use hogan::config::ConfigUrl;
 use regex::{Regex, RegexBuilder};
 use std::path::PathBuf;

--- a/src/app/datadogstatsd.rs
+++ b/src/app/datadogstatsd.rs
@@ -82,6 +82,7 @@ impl DdMetrics {
 pub enum CustomMetrics {
     CacheMiss,
     CacheHit,
+    Cache,
     RequestTime,
 }
 
@@ -90,6 +91,7 @@ impl CustomMetrics {
         match self {
             CustomMetrics::CacheMiss => "hogan.cache_miss.counter",
             CustomMetrics::CacheHit => "hogan.cache_hit.counter",
+            CustomMetrics::Cache => "hogan.cache",
             CustomMetrics::RequestTime => "hogan.requests",
         }
     }

--- a/src/app/datadogstatsd.rs
+++ b/src/app/datadogstatsd.rs
@@ -36,6 +36,7 @@ impl DdMetrics {
             .unwrap_or_else(|err| self.error_msg(name, &err.to_string()));
     }
 
+    #[allow(dead_code)]
     pub fn decr(&self, name: &str, additional_tags: Option<Vec<String>>) {
         self.client
             .decr(
@@ -48,6 +49,7 @@ impl DdMetrics {
             .unwrap_or_else(|err| self.error_msg(name, &err.to_string()));
     }
 
+    #[allow(dead_code)]
     pub fn gauge(&self, name: &str, additional_tags: Option<Vec<String>>, value: &str) {
         self.client
             .gauge(
@@ -80,8 +82,6 @@ impl DdMetrics {
 }
 
 pub enum CustomMetrics {
-    CacheMiss,
-    CacheHit,
     Cache,
     RequestTime,
 }
@@ -89,8 +89,6 @@ pub enum CustomMetrics {
 impl CustomMetrics {
     pub fn metrics_name(self) -> &'static str {
         match self {
-            CustomMetrics::CacheMiss => "hogan.cache_miss.counter",
-            CustomMetrics::CacheHit => "hogan.cache_hit.counter",
             CustomMetrics::Cache => "hogan.cache",
             CustomMetrics::RequestTime => "hogan.requests",
         }

--- a/src/app/db.rs
+++ b/src/app/db.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use hogan::config::Environment;
 use rusqlite::{params, Connection, OpenFlags, NO_PARAMS};
 use serde::Deserialize;
@@ -23,7 +23,7 @@ fn open_sql_db(db_path: &str, read_only: bool) -> Result<Connection> {
         )?;
     }
 
-    info!("Opened sqlite connection to {}", db_path);
+    debug!("Opened sqlite connection to {}", db_path);
 
     Ok(conn)
 }
@@ -44,7 +44,7 @@ pub fn read_sql_env(db_path: &str, env: &str, sha: &str) -> Result<Option<Enviro
         };
         Ok(Some(decoded.into()))
     } else {
-        info!("Unable to find {} in sqlite db", key);
+        debug!("Unable to find {} in sqlite db", key);
         Ok(None)
     }
 }
@@ -55,7 +55,7 @@ pub fn write_sql_env(db_path: &str, env: &str, sha: &str, data: &Environment) ->
     let env_data: WritableEnvironment = data.into();
     let data = bincode::serialize(&env_data)?;
 
-    info!("Writing to DB. Key: {} Size: {}", key, data.len());
+    debug!("Writing to DB. Key: {} Size: {}", key, data.len());
 
     conn.execute(
         "INSERT INTO hogan (key, data) VALUES (?1, ?2)",

--- a/src/app/head.rs
+++ b/src/app/head.rs
@@ -121,7 +121,7 @@ pub fn request_branch_head(sender: &Sender<HeadRequest>, branch: &str) -> anyhow
     match sender.send(request) {
         Ok(()) => match return_chan.recv_timeout(std::time::Duration::from_secs(60)) {
             Ok(result) => result.with_context(|| format!("Querying for head of {}", branch)),
-            Err(e) => Err(HoganError::InternalTimeout.into()),
+            Err(_e) => Err(HoganError::InternalTimeout.into()),
         },
         Err(e) => {
             warn!("Unable to send head request {} {:?}", branch, e);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
+use crate::error::HoganError;
 use crate::find_file_paths;
 use crate::git;
-use failure::Error;
+use anyhow::{Context, Result};
 use json_patch::merge;
 use regex::Regex;
 use regex::RegexBuilder;
@@ -25,9 +26,9 @@ pub enum ConfigUrl {
 }
 
 impl FromStr for ConfigUrl {
-    type Err = Error;
+    type Err = anyhow::Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self> {
         match Url::parse(&s) {
             Ok(url) => {
                 if url.scheme() == "file" {
@@ -37,7 +38,10 @@ impl FromStr for ConfigUrl {
                 } else {
                     let path_segments = url
                         .path_segments()
-                        .ok_or_else(|| format_err!("Url cannot be a base"))?
+                        .ok_or_else(|| HoganError::InvalidConfiguration {
+                            param: "url".to_string(),
+                            msg: "Url cannot be a base".to_string(),
+                        })?
                         .map(|segment| segment.to_owned())
                         .collect::<Vec<String>>();
 
@@ -57,7 +61,10 @@ impl FromStr for ConfigUrl {
 
                                 git_url
                                     .path_segments_mut()
-                                    .map_err(|_| format_err!("Url cannot be a base"))?
+                                    .map_err(|_| HoganError::InvalidConfiguration {
+                                        param: "url".to_string(),
+                                        msg: "Url cannot be a base".to_string(),
+                                    })?
                                     .clear()
                                     .extend(base_segments);
 
@@ -70,7 +77,11 @@ impl FromStr for ConfigUrl {
                                 internal_path,
                             })
                         }
-                        None => bail!("Config Url not a file path, and not a .git URL"),
+                        None => Err(HoganError::InvalidConfiguration {
+                            msg: "Config Url not a file path, and not a .git URL".to_string(),
+                            param: "url".to_string(),
+                        }
+                        .into()),
                     }
                 }
             }
@@ -100,14 +111,16 @@ pub enum ConfigDir {
 }
 
 impl ConfigDir {
-    pub fn new(url: ConfigUrl, ssh_key_path: &Path) -> Result<ConfigDir, Error> {
+    pub fn new(url: ConfigUrl, ssh_key_path: &Path) -> Result<ConfigDir> {
         let config_dir = match url {
             ConfigUrl::Git {
                 url,
                 branch,
                 internal_path,
             } => {
-                let temp_dir = tempfile::tempdir()?;
+                let temp_dir = tempfile::tempdir().map_err(|e| HoganError::GitError {
+                    msg: format!("Unable to create temp directory {:?}", e),
+                })?;
 
                 let git_repo = git::clone(
                     &url,
@@ -120,7 +133,12 @@ impl ConfigDir {
 
                 let directory = match git_repo.workdir() {
                     Some(workdir) => workdir.join(internal_path),
-                    None => bail!("No working directory found for git repository"),
+                    None => {
+                        return Err(HoganError::GitError {
+                            msg: "No working directory found for git repository".to_string(),
+                        }
+                        .into())
+                    }
                 };
                 let ssh_key_path = ssh_key_path.to_owned();
 
@@ -137,17 +155,20 @@ impl ConfigDir {
 
         if let Ok(ref config_dir) = config_dir {
             if !config_dir.directory().is_dir() {
-                bail!(
-                    "{:?} either does not exist or is not a directory. It needs to be both",
-                    config_dir.directory()
-                )
+                return Err(HoganError::UnknownError {
+                    msg: format!(
+                        "{:?} either does not exist or is not a directory. It needs to be both",
+                        config_dir.directory()
+                    ),
+                }
+                .into());
             }
         }
 
         config_dir
     }
 
-    pub fn extend(&self, branch: &str) -> Result<ConfigDir, Error> {
+    pub fn extend(&self, branch: &str) -> Result<ConfigDir> {
         match self {
             ConfigDir::Git {
                 url, ssh_key_path, ..
@@ -159,7 +180,10 @@ impl ConfigDir {
                 },
                 ssh_key_path,
             ),
-            ConfigDir::File { .. } => Err(format_err!("Can not extend file config")),
+            ConfigDir::File { .. } => Err(HoganError::GitError {
+                msg: "Can not extend file config".to_string(),
+            }
+            .into()),
         }
     }
 
@@ -170,40 +194,30 @@ impl ConfigDir {
         }
     }
 
-    pub fn refresh(&self, remote: Option<&str>, target: Option<&str>) -> Option<String> {
+    pub fn refresh(&self, remote: Option<&str>, target: Option<&str>) -> Result<String> {
         match self {
-            ConfigDir::File { .. } => None,
+            ConfigDir::File { .. } => Err(HoganError::GitError {
+                msg: "Cannot refresh a file config".to_string(),
+            }
+            .into()),
             ConfigDir::Git {
                 directory,
                 url,
                 ssh_key_path,
                 ..
             } => {
-                let git_repo = match git::build_repo(directory.to_str().unwrap()) {
-                    Ok(repo) => repo,
-                    Err(e) => {
-                        error!(
-                            "Error: {} \n Unable to find the git repo: {}",
-                            e,
-                            directory.to_str().unwrap()
-                        );
-                        return None;
-                    }
-                };
-                match git::reset(
+                let git_repo = git::build_repo(directory.to_str().unwrap())
+                    .with_context(|| "Attempting to refresh git repo -- Building Repo")?;
+
+                git::reset(
                     &git_repo,
                     remote.unwrap_or("origin"),
                     Some(ssh_key_path),
                     Some(url),
                     target,
                     false,
-                ) {
-                    Ok(sha) => Some(sha),
-                    Err(e) => {
-                        error!("Error refreshing to {:?} {:?}", target, e);
-                        None
-                    }
-                }
+                )
+                .with_context(|| format!("Error refreshing to {:?}", target))
             }
         }
     }
@@ -269,43 +283,26 @@ impl ConfigDir {
         )
     }
 
-    pub fn find_branch_head(&self, remote_name: &str, branch_name: &str) -> Option<String> {
+    pub fn find_branch_head(&self, remote_name: &str, branch_name: &str) -> Result<String> {
         match self {
-            ConfigDir::File { .. } => None,
+            ConfigDir::File { .. } => Err(HoganError::GitError {
+                msg: "Unable to perform git actions on a file".to_string(),
+            })
+            .context("Finding branch head"),
             ConfigDir::Git {
                 directory,
                 ssh_key_path,
                 url,
                 ..
             } => {
-                let git_repo = match git::build_repo(directory.to_str().unwrap()) {
-                    Ok(repo) => repo,
-                    Err(e) => {
-                        error!(
-                            "Error: {} \n Unable to find the git repo: {}",
-                            e,
-                            directory.to_str().unwrap()
-                        );
-                        return None;
-                    }
-                };
+                let git_repo = git::build_repo(directory.to_str().unwrap())
+                    .with_context(|| "Finding branch head")?;
 
-                match git::fetch(&git_repo, remote_name, Some(ssh_key_path), Some(url)) {
-                    Err(e) => {
-                        warn!("Error updating git repo: {:?}", e);
-                        return None;
-                    }
-                    Ok(()) => (),
-                }
+                git::fetch(&git_repo, remote_name, Some(ssh_key_path), Some(url))
+                    .with_context(|| "Finding branch head, updating repo")?;
 
-                match git::find_branch_head(&git_repo, &format!("{}/{}", remote_name, branch_name))
-                {
-                    Ok(sha) => Some(sha),
-                    Err(e) => {
-                        warn!("Unable to find branch: {:?}", e);
-                        None
-                    }
-                }
+                git::find_branch_head(&git_repo, &format!("{}/{}", remote_name, branch_name))
+                    .with_context(|| "Finding branch head, querying for head")
             }
         }
     }
@@ -349,14 +346,20 @@ struct EnvironmentType {
     config_data: Value,
 }
 
-pub fn build_regex(pattern: &str) -> Result<Regex, Error> {
+pub fn build_regex(pattern: &str) -> Result<Regex> {
     RegexBuilder::new(pattern)
         .case_insensitive(true)
         .build()
-        .map_err(|e| e.into())
+        .map_err(|e| {
+            HoganError::InvalidConfiguration {
+                param: "regex".to_string(),
+                msg: format!("Regex Error: {:?}", e),
+            }
+            .into()
+        })
 }
 
-pub fn build_env_regex(env: &str, base_pattern: Option<&str>) -> Result<Regex, Error> {
+pub fn build_env_regex(env: &str, base_pattern: Option<&str>) -> Result<Regex> {
     let pattern = match base_pattern {
         Some(base) => {
             let raw = String::from(base);

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,9 +275,9 @@ impl ConfigDir {
                         .ok()
                         .and_then(|f| serde_json::from_reader(f).ok())
                         .and_then(|c: Config| c.into_environment_type())
-                        .and_then(|mut e| {
+                        .map(|mut e| {
                             e.environment_type = env_type;
-                            Some(e)
+                            e
                         })
                 }),
         )

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,45 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone)]
+pub enum HoganError {
+    #[error("There was an error with the underlying git repository. {msg}")]
+    GitError { msg: String },
+    #[error("The requested SHA {sha} was not found in the git repo")]
+    UnknownSHA { sha: String },
+    #[error("The requested branch {branch} was not found in the git repo")]
+    UnknownBranch { branch: String },
+    #[error("The requested environment {env} was not found in {sha}")]
+    UnknownEnvironment { sha: String, env: String },
+    #[error("There was a problem with the provided template")]
+    InvalidTemplate { msg: String },
+    #[error("The request was malformed")]
+    BadRequest,
+    #[error("Request timed out due to internal congestion")]
+    InternalTimeout,
+    #[error("An error occurred parsing configuration {param}: {msg}")]
+    InvalidConfiguration { param: String, msg: String },
+    #[error("An unknown error occurred. {msg}")]
+    UnknownError { msg: String },
+}
+
+impl From<git2::Error> for HoganError {
+    fn from(e: git2::Error) -> Self {
+        HoganError::GitError {
+            msg: e.message().to_owned(),
+        }
+    }
+}
+
+impl From<anyhow::Error> for HoganError {
+    fn from(e: anyhow::Error) -> Self {
+        match e.downcast() {
+            Ok(e) => e,
+            Err(e) => {
+                warn!("Bad cast to a HoganError {:?}", e);
+                HoganError::UnknownError {
+                    msg: format!("Error {:?}", e),
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,10 @@
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
 pub mod config;
+pub mod error;
 pub mod git;
 pub mod template;
 pub mod transform;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
@@ -8,19 +6,20 @@ extern crate lazy_static;
 use crate::app::cli;
 use crate::app::config::{App, AppCommand};
 use crate::app::server;
-use failure::Error;
-use structopt;
+use anyhow::{Context, Result};
 use structopt::StructOpt;
 
 mod app;
 
-fn main() -> Result<(), Error> {
+fn main() -> Result<()> {
     let opt = App::from_args();
 
     stderrlog::new()
         .module(module_path!())
         .verbosity(opt.verbosity + 2)
-        .init()?;
+        .timestamp(stderrlog::Timestamp::Millisecond)
+        .init()
+        .with_context(|| "Error initializing logging")?;
 
     match opt.cmd {
         AppCommand::Transform {


### PR DESCRIPTION
This is a pretty big PR...
One of the main complaints that we have had is that error handling is terse and inconsistent for API responses.
This change centralizes error handling and allows us to differentiate between types of errors. As part of this `failure` was swapped out for `anyhow`. `failure` has been deprecated due to improvements to the base `Error` trait.

The routes all remain the same (as to their `OK` responses). All error responses have been upgraded and all return a JSON body.