### PR TITLE
remove Null values from the global context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY ./Cargo.* ./
 
 # Builds your dependencies and removes the
 # fake source code from the dummy project
-RUN cargo build --release
+RUN cargo build --release 
 RUN rm src/*.rs
 RUN rm target/x86_64-unknown-linux-musl/release/hogan
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,7 +269,9 @@ impl ConfigDir {
                     &Value::Null
                 };
 
-                let mut config_data = global.clone(); // Start with global
+                let mut config_data = Value::Null; // Start with Null to remove Null values from contexts
+
+                merge(&mut config_data, global); // Merge in global config
                 merge(&mut config_data, parent); // Merge in an env type
                 merge(&mut config_data, &environment.config_data); // Merge with the actual config
 
@@ -608,6 +610,22 @@ mod tests {
 
         let mut merged = global.clone();
 
+        merge(&mut merged, &parent);
+        merge(&mut merged, &doc);
+
+        let expected_json: Value = serde_json::from_str(r#"{"a": 2}"#).unwrap();
+
+        assert_eq!(merged, expected_json)
+    }
+
+    #[test]
+    fn test_null_merge() {
+        let global: Value = serde_json::from_str(r#"{"a": null, "b": null, "c": null}"#).unwrap();
+        let parent = serde_json::from_str(r#"{"a": 1}"#).unwrap();
+        let doc = serde_json::from_str(r#"{"a": 2, "b": null}"#).unwrap();
+
+        let mut merged = Value::Null;
+        merge(&mut merged, &global);
         merge(&mut merged, &parent);
         merge(&mut merged, &doc);
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -22,6 +22,7 @@ use self::helper_yaml_string::YamlStringHelper;
 //To maintain backwards compatibility we are reverting to the original default escape fn
 pub fn old_escape_html(s: &str) -> String {
     let mut output = String::new();
+
     for c in s.chars() {
         match c {
             '<' => output.push_str("&lt;"),


### PR DESCRIPTION
This isn't a breaking change with non-strict evaluation. Null renders to empty
In strict mode now we will now error on Null values not just missing strings (reducing both to the same case)